### PR TITLE
support the wildcard VirtualHost with multiprocess handler.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Tue Aug 28 17:03:20 2012  CHIKANAGA Tomoyuki  <nagachika@ruby-lang.org>
+	* lib/rack/handler/ennoumu.rb: support the wildcard VirtualHost with
+	  multiprocess handler.
 Thu Aug 16 14:11:12 2012 Tajima Akio <artonx@yahoo.co.jp>
 	* lib/rack/hanlder/ennoumu.rb: fix typo of qname variable's name
 Tue Aug 14 23:25:30 2012 Tajima Akio <artonx@yahoo.co.jp>

--- a/lib/rack/handler/ennoumu.rb
+++ b/lib/rack/handler/ennoumu.rb
@@ -34,7 +34,7 @@ module Rack
               server.add "http://#{@host}:#{@port}#{@script}/"
             end
             pids = []
-            cmd = "#{::File.expand_path('../ruby.exe', $0)} #{::File.expand_path("../#{@rackup}", $0)} #{$DEBUG ? '-d' : ''} #{$VERBOSE ? '-w' : ''} #{@host == '+' ? '' : "-o #{@host}"} -p #{@port} -s Ennoumu \"#{options[:config]}\""
+            cmd = "#{::File.expand_path('../ruby.exe', $0)} #{::File.expand_path("../#{@rackup}", $0)} #{$DEBUG ? '-d' : ''} #{$VERBOSE ? '-w' : ''} #{options[:Host] == '0.0.0.0' ? '' : "-o #{@host}"} -p #{@port} -s Ennoumu \"#{options[:config]}\""
             1.upto(@nprocs) do
               pids << spawn(cmd)
               @logger.info " spawn worker pid=#{pids.last}"


### PR DESCRIPTION
rackup に明示的にワイルドカードの virtual host 指定(-o "+")を渡して起動すると、Handler に Ennoumu を利用する場合(複数プロセスを起動する場合)、controller の @host は "+" になるのですが、controller から spawn される子プロセスの rackup コマンドラインが -o なしになるため、サブディレクトリによる運用と判断されて http://+:80/<アプリ名>/ にマッピングされてしまうようです。
この pull request では子プロセスのコマンドラインを構築する時に @host == "+" ではなくてその元となる options[:Host] を直接チェックするようにして options[:Host]に元々 "+" が指定されていた時にそれが子プロセスに伝播するようにしています。

背景としては、Windows Azure 上で(NougakuDoCompanion 経由で) VirtualHost による運用を選択して Rails アプリケーションを動かそうとしています。Azure では Swap Deployment という方式で、production と staging という環境にそれぞれアプリをデプロイして、swap という操作で Virtual IP を切り替えることで無停止アップデートが可能です。 http://msdn.microsoft.com/en-us/library/windowsazure/hh386336.aspx
しかし staging にアクセスするドメイン名が異なるので、virtual host 方式では production 用の virtual host の設定をしてデプロイすると staging 環境の Rails サーバにアクセスできず、動作確認ができません。
このため NougakuDoCompanion の VirtualHost の設定にワイルドカード("+")を明示的に指定するという方法で回避を試みたところ、1プロセスの時はこれでうまくいくのですが、複数プロセスの時にサブディレクトリによる運用のモードになってしまったということです。
