### PR TITLE
make ruby.exe path from 'bindir'.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 Tue Aug 28 17:03:20 2012  CHIKANAGA Tomoyuki  <nagachika@ruby-lang.org>
+	* lib/rack/handler/ennoumu.rb: make ruby.exe path from 'bindir'.
+	  bacause 'rackup' could not be the script bundled with NougakuDo when
+	  executed via 'bundle exec'.
+Tue Aug 28 17:03:20 2012  CHIKANAGA Tomoyuki  <nagachika@ruby-lang.org>
 	* lib/rack/handler/ennoumu.rb: support the wildcard VirtualHost with
 	  multiprocess handler.
 Thu Aug 16 14:11:12 2012 Tajima Akio <artonx@yahoo.co.jp>

--- a/lib/rack/handler/ennoumu.rb
+++ b/lib/rack/handler/ennoumu.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+require "rbconfig"
+
 require_relative './ennou.rb'
 
 module Rack
@@ -34,7 +36,7 @@ module Rack
               server.add "http://#{@host}:#{@port}#{@script}/"
             end
             pids = []
-            cmd = "#{::File.expand_path('../ruby.exe', $0)} #{::File.expand_path("../#{@rackup}", $0)} #{$DEBUG ? '-d' : ''} #{$VERBOSE ? '-w' : ''} #{options[:Host] == '0.0.0.0' ? '' : "-o #{@host}"} -p #{@port} -s Ennoumu \"#{options[:config]}\""
+            cmd = "#{::File.expand_path('ruby.exe', RbConfig::CONFIG["bindir"])} #{::File.expand_path("../#{@rackup}", $0)} #{$DEBUG ? '-d' : ''} #{$VERBOSE ? '-w' : ''} #{options[:Host] == '0.0.0.0' ? '' : "-o #{@host}"} -p #{@port} -s Ennoumu \"#{options[:config]}\""
             1.upto(@nprocs) do
               pids << spawn(cmd)
               @logger.info " spawn worker pid=#{pids.last}"


### PR DESCRIPTION
ennoumu.rb で Process.spawn に渡すためのコマンドラインの ruby.exe のパスを RbConfig::CONFIG["bindir"] を元に生成するようにしています。

現在は ruby.exe のパスを生成するために $0 (rackup) のパスを元にしていますが、Bundler を用いて rails アプリの起動に "bundle exec" をつけて起動するようにすると、能楽堂に添付されている bin\rackup ではなく bundle install でインストールされた rackup が使われるため、この $0 を元に ruby.exe のパスを生成すると "No such file or directory" エラーになってしまいます。
ruby.exe はアプリの場所にかかわらず ruby の環境(能楽堂)のインストール先のものを利用するようにするのが良いかと思いましたので RbConfig の "bindir" の設定値を利用するようにしてみました。
